### PR TITLE
Fix debug apps hook

### DIFF
--- a/main/java/net/fypm/InstallerOpt/Main.java
+++ b/main/java/net/fypm/InstallerOpt/Main.java
@@ -1597,7 +1597,7 @@ public class Main implements IXposedHookZygoteInit, IXposedHookLoadPackage, IXpo
                         "checkSignatures", checkSignaturesHook);
 
                 // 4.0 and newer
-                XposedBridge.hookAllMethods(Process.class, "start",
+                XposedBridge.hookAllMethods(android.os.Process.class, "start",
                         debugAppsHook);
 
                 // 5.0 and newer


### PR DESCRIPTION
Hook into android Process class instead of Java Process class. This is why debug apps hook wasn't working. Started working after this fix.
